### PR TITLE
Fix compile errors

### DIFF
--- a/impl.h
+++ b/impl.h
@@ -75,6 +75,7 @@
 #endif
 #include <stdarg.h>
 #include <dlfcn.h>
+#include <ctype.h>
 
 struct gimli_mapped_object;
 typedef struct gimli_mapped_object *gimli_mapped_object_t;

--- a/print.c
+++ b/print.c
@@ -558,11 +558,11 @@ static int print_var(struct print_data *data, gimli_type_t t, const char *varnam
         snprintf(addrkey, sizeof(addrkey), "%p:%" PRIx64, t, addr);
         if (gimli_hash_find(derefd, addrkey, &dummy)) {
           printf(" " PTRFMT " [deref'd above]\n", addr);
-          return;
+          return GIMLI_ITER_CONT;
         }
         if (!gimli_hash_insert(derefd, addrkey, NULL)) {
           printf(" " PTRFMT " <hash insert failed>\n", addr);
-          return;
+          return GIMLI_ITER_ERR;
         }
 
         printf(" " PTRFMT " = {\n", addr);


### PR DESCRIPTION
Fix compile errors on clang-602.0.53, target: x86_64-apple-darwin14.3.0.
